### PR TITLE
Move dml speech after wrapper box 20

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -62,7 +62,7 @@
 
                 <ul>
                     <li><a href="mailto:press@mozilla.org">Press inquiries</a></li>
-                    <li>Read our <a href="{{ LOCALE_ROOT }}faq.html">FAQ</a></li>
+                    <li>Visit our <a href="http://wiki.mozilla.org/Badges">wiki</a></li>
                     <li>Fork our code on <a href="https://github.com/mozilla/openbadges">GitHub</a></li>
 
                 </ul>

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,7 +61,7 @@
                 <h2>Learn more</h2>
 
                 <ul>
-                    <li>Join <a href="http://www.mozilla.org/about/mission.html">Mozilla's mission</a></li>
+                    <li><a href="mailto:press@mozilla.org">Press inquiries</a></li>
                     <li>Read our <a href="{{ LOCALE_ROOT }}faq.html">FAQ</a></li>
                     <li>Fork our code on <a href="https://github.com/mozilla/openbadges">GitHub</a></li>
 
@@ -72,7 +72,7 @@
                 <ul>
                     <li>Learn about <a href="http://www.mozilla.org/about/mission.html">Mozilla's mission</a></li>
                     <li>Join <a href="https://donate.mozilla.org/join/">Mozilla</a></li>
-                    <li>Like us on <a href="http://www.facebook.com/mozilladrumbeat/">Facebook</a></li>
+                    <li>Like us on <a href="http://www.facebook.com/MozillaOpenBadges">Facebook</a></li>
                 </ul>
             </div>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,6 @@
 {% endblock %}
 
 {% block content %}
-      <div id="dml-speech" class="box">Learn more about the <a href="{{ LOCALE_ROOT }}faq.html#dml-competition">DML Badge Competition</a>!</div>
 <section id="content">
   <section id="what-are-badges">
     <div class="wrapper box">
@@ -28,6 +27,7 @@
       <a href="#badges-101" id="get-started" class="button fancybox">get started</a>
       <div id="hands"></div>
     </div>
+    <div id="dml-speech" class="box">Learn more about the <a href="{{ LOCALE_ROOT }}faq.html#dml-competition">DML Badge Competition</a>!</div>
   </section>
   <section id="issuer-user-displayer">
     <div class="col box">


### PR DESCRIPTION
This solves GH #20 without adding z-index and creates a more semantic document with the "want to know more about DML Badge competition" text after the "What are Open Badges?" introduction.
