### PR TITLE
Removed unused html-elements for IE

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<!--[if (lt IE 9)]><html class="no-js bad-ie" lang="en-US" dir="ltr"><![endif]-->
-<!--[if (gt IE 8)|!(IE)]><html class="no-js" lang="en-US" dir="ltr"><![endif]-->
+<html class="no-js" lang="en-US" dir="ltr">
 <head>
     <title>Open Badges</title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">


### PR DESCRIPTION
.bad-ie is never used in the css. No need to add these conditional comments if they are not used.

If this pull request will be denied you will need to fix the conditional comments anyway, because the way it's implemented right now non-ie browsers will not get a html element.

The correct way of implementing a CC like you want it is: :)

```
<!--[if lt IE 9]><html class="no-js bad-ie" lang="en-US" dir="ltr"><![endif]-->
<!--[if gt IE 8]><!--><html class="no-js" lang="en-US" dir="ltr"><!--<![endif]-->
```
