### PR TITLE
removed unnecessary attributes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,18 +3,18 @@
 <head>
     <title>Open Badges</title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
-    <link rel="stylesheet" media="screen,projection,tv" href="/css/normalise.css" />
-    <link rel="stylesheet" media="screen,projection,tv" href="/css/devices.css" />
-    <link href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" rel="stylesheet" media="screen, projection, tv"/> 
+    <link rel="stylesheet" href="/css/normalise.css" />
+    <link rel="stylesheet" href="/css/devices.css" />
+    <link rel="stylesheet" href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" /> 
     <link rel="stylesheet" media="all and (min-width:30em)" href="/css/desktop.css" />
     <!--[if lt IE 9]>
-        <script type="text/javascript" src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-        <link rel="stylesheet" media="screen" href="/css/desktop.css" />
+        <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <link rel="stylesheet" href="/css/desktop.css" />
     <![endif]-->
     {% block head %} {% endblock %}
 </head>
 <body>
-    <script type="text/javascript">
+    <script>
         document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, '');
     </script>
     <div id="header-and-content">
@@ -53,7 +53,7 @@
 
                 <p>Join the conversation, tell us how you are using Open Badges</p>
                 <a href="https://twitter.com/openbadges" class="twitter-follow-button" data-width="350px" data-show-count="false">Follow @openbadges</a>
-                <script src="//platform.twitter.com/widgets.js" type="text/javascript"></script>
+                <script src="//platform.twitter.com/widgets.js"></script>
             </div>
             <div class="col box learn">
                 <h2>Learn more</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,12 +3,12 @@
 {% block page_id %}index{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" type="text/css" href="/css/badges101.css" media="screen" />
-  <link rel="stylesheet" type="text/css" href="/css/jquery.fancybox.css" media="screen" />
+  <link rel="stylesheet" href="/css/badges101.css" />
+  <link rel="stylesheet" href="/css/jquery.fancybox.css" />
 {% endblock %}
 {% block bodyend %}
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js"></script>
-  <script type="text/javascript" src="/scripts/jquery.fancybox.js"></script>
+  <script src="/scripts/jquery.fancybox.js"></script>
   <script src="/scripts/slides.min.jquery.js"></script>
   <script src="/scripts/quickbadge.js"></script>
   <script src="http://beta.openbadges.org/issuer.js"></script>


### PR DESCRIPTION
The media attribute on link rel="stylesheet" defaults to all http://developers.whatwg.org/semantics.html#attr-link-media

The type attribute is unnecessary on link rel="stylesheet" and script-elements
